### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and do not need to be memorized.
 
 ```$ pip install magic-wormhole```
 
-On Debian/Ubuntu systems, you may first need `apt-get python-dev libffi-dev`.
+On Debian/Ubuntu systems, you may first need `apt-get python-dev libffi-dev libsodium-dev`.
 On OS-X, you may need to install `pip`.
 
 Developers can clone the source tree and run `tox` to run the unit tests on


### PR DESCRIPTION
I needed `libsodium-dev` on an Ubuntu 15.10 machine, since without it I was getting 

```bash
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector-strong -Wformat -Werror=format-security -D_FO
RTIFY_SOURCE=2 -fPIC -I/usr/include/python3.4m -c build/temp.linux-x86_64-3.4/_sodium.c -o build/temp.linux-x86_64-3.4/build/temp.linux-x86_64-3.4
/_sodium.o

build/temp.linux-x86_64-3.4/_sodium.c:390:20: fatal error: sodium.h: No such file or directory

compilation terminated.

error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```