### PR TITLE
allow appveyor python3+ builds to fail

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,16 @@ environment:
     - PYTHON: "C:\\Python35-x64"
       DISTUTILS_USE_SDK: "1"
 
+matrix:
+  allow_failures:
+      # we allow all python3 versions to fail without as they do not currently work
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python33-x64"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35-x64"
+
 # tox-2.3.1 has a windows bug (#314), fixed in hg but not yet released. When
 # the next release comes out, replace this with just:
 #   %PYTHON%\python.exe -m pip install wheel tox


### PR DESCRIPTION
Added a small section to appveyor config file to allow the python3 windows builds to fail without warning of build failure. I'll look deeper into the windows issues to see if I can get the tests passing and then add the `[windows]` build extra. If I can I'll revert the config back.