### PR TITLE
added [windows] extra to encapsulate windows dependancies #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ and do not need to be memorized.
 On Debian/Ubuntu systems, you may first need `apt-get python-dev
 libffi-dev`. On Fedora it's `libffi-devel` and `python-devel`. On OS-X,
 you may need to install `pip` and run `xcode-select --install` to get
-GCC.
+GCC. On Windows you will need to use `pip install magic-wormhole[windows]`
+to install the extra required libraries. (Note: only python2 is supported
+on windows at this time).
 
 Developers can clone the source tree and run `tox` to run the unit tests on
 all supported (and installed) versions of python: 2.7, 3.3, 3.4, and 3.5.

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,9 @@ setup(name="magic-wormhole",
                         "autobahn[twisted] >= 0.14.1",
                         "hkdf", "tqdm",
                         ],
-      extras_require={"tor": ["txtorcon", "ipaddr"]},
+      extras_require={"tor": ["txtorcon", "ipaddr"],
+                      "windows": ["pypiwin32"]
+                      },
       test_suite="wormhole.test",
       cmdclass=commands,
       )


### PR DESCRIPTION
adds the windows extra to the package that explicitly adds pypiwin32 as a dependency.

should be invoked with `pip install magic-wormhole[windows]` as per issue #25.