### PR TITLE
Prevent transmit from suggesting `127.0.0.1`

### DIFF
--- a/src/wormhole/test/test_transit.py
+++ b/src/wormhole/test/test_transit.py
@@ -163,7 +163,6 @@ class Basic(unittest.TestCase):
         self.assertEqual(c._their_direct_hints, [])
         self.assertEqual(c._their_relay_hints, [])
 
-    # @inlineCallbacks
     def test_ignore_localhost_hint(self):
         # this actually starts the listener
         c = transit.TransitSender(u"")

--- a/src/wormhole/test/test_transit.py
+++ b/src/wormhole/test/test_transit.py
@@ -163,6 +163,18 @@ class Basic(unittest.TestCase):
         self.assertEqual(c._their_direct_hints, [])
         self.assertEqual(c._their_relay_hints, [])
 
+    # @inlineCallbacks
+    def test_ignore_localhost_hint(self):
+        # this actually starts the listener
+        c = transit.TransitSender(u"")
+        results = []
+        d = c.get_connection_hints()
+        d.addBoth(results.append)
+        hints = results[0]
+        c._stop_listening()
+        for hint in hints:
+            self.assertFalse(hint[u'hostname'] == u'127.0.0.1')
+
     def test_transit_key_wait(self):
         KEY = b"123"
         c = transit.Common(u"")

--- a/src/wormhole/transit.py
+++ b/src/wormhole/transit.py
@@ -612,10 +612,11 @@ class Common:
         hints = []
         direct_hints = yield self._get_direct_hints()
         for dh in direct_hints:
-            hints.append({u"type": u"direct-tcp-v1",
-                          u"hostname": dh.hostname,
-                          u"port": dh.port, # integer
-                          })
+            if dh.hostname != '127.0.0.1':
+                hints.append({u"type": u"direct-tcp-v1",
+                              u"hostname": dh.hostname,
+                              u"port": dh.port, # integer
+                              })
         for relay in self._transit_relays:
             rhint = {u"type": u"relay-v1", u"hints": []}
             for rh in relay.hints:


### PR DESCRIPTION
The test runs the listener locally, which can turn up 127.0.0.1.
The added code in transmit stops the hint.