### PR TITLE
zipfile perms

### DIFF
--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -223,7 +223,7 @@ class TwistedReceiver:
         destname = os.path.basename(destname)
         if self.args.output_file:
             destname = self.args.output_file # override
-        abs_destname = os.path.join(self.args.cwd, destname)
+        abs_destname = os.path.abspath( os.path.join(self.args.cwd, destname) )
 
         # get confirmation from the user before writing to the local directory
         if os.path.exists(abs_destname):
@@ -290,11 +290,16 @@ class TwistedReceiver:
             the zipfile module does not restore file permissions
             so we'll do it manually
             """
+            out_path = os.path.join( extract_dir, info.filename )
+            out_path = os.path.abspath( out_path )
+            if not out_path.startswith( extract_dir ):
+                raise ValueError( "malicious zipfile, %s outside of extract_dir %s"
+                        % (info.filename, extract_dir) )
+
             zf.extract( info.filename, path=extract_dir )
 
             # not sure why zipfiles store the perms 16 bits away but they do
-            perm = info.external_attr >> 16L
-            out_path = os.path.join( extract_dir, info.filename )
+            perm = info.external_attr >> 16
             os.chmod( out_path, perm )
 
         self._msg(u"Unpacking zipfile..")

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -197,7 +197,6 @@ class Sender:
             # We're sending a directory. Create a zipfile in a tempdir and
             # send that.
             fd_to_send = tempfile.SpooledTemporaryFile()
-            # TODO: I think ZIP_DEFLATED means compressed.. check it
             num_files = 0
             num_bytes = 0
             tostrip = len(what.split(os.sep))


### PR DESCRIPTION
when sending a directory the file permissions are not preserved. this is a deficiency with the python zipfile module so we need to work around it.