### PR TITLE
pep 508 and windows builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
   # that didn't work (it seems to work when I run it locally, but on appveyor
   # it fails to install the pypiwin32 package). So don't bother telling
   # Twisted to support windows: just install it ourselves.
-  EXTRA_DEPENDENCY: "pypiwin32"
+  # EXTRA_DEPENDENCY: "pypiwin32"
   matrix:
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ and do not need to be memorized.
 On Debian/Ubuntu systems, you may first need `apt-get python-dev
 libffi-dev`. On Fedora it's `libffi-devel` and `python-devel`. On OS-X,
 you may need to install `pip` and run `xcode-select --install` to get
-GCC. On Windows you will need to use `pip install magic-wormhole[windows]`
-to install the extra required libraries. (Note: only python2 is supported
-on windows at this time).
+GCC. Note: on Windows, only python2 is currently supported.
 
 Developers can clone the source tree and run `tox` to run the unit tests on
 all supported (and installed) versions of python: 2.7, 3.3, 3.4, and 3.5.

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,8 @@ setup(name="magic-wormhole",
                         "autobahn[twisted] >= 0.14.1",
                         "hkdf", "tqdm",
                         ],
-      extras_require={"tor": ["txtorcon", "ipaddress"],
-                      "windows": ["pypiwin32"]
-                      },
+      extras_require={':sys_platform=="win32"': ["pypiwin32"],
+                      "tor": ["txtorcon", "ipaddress"]},
       test_suite="wormhole.test",
       cmdclass=commands,
       )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py33,py34,py35
+envlist = {py27,py33,py34,py35}
 skip_missing_interpreters = True
 
 # On windows we need "pypiwin32" installed. It's supposedly possible to make
@@ -20,11 +20,12 @@ skip_missing_interpreters = True
 deps =
     pyflakes >= 1.2.3
     mock
-    {env:EXTRA_DEPENDENCY:}
+install_command= pip install {packages}
 commands =
     pyflakes setup.py src
     wormhole --version
-    trial {posargs:wormhole.test}
+    python -m wormhole.test.run_trial {posargs:wormhole.test}
+
 
 # on windows, trial is installed as venv/bin/trial.py, not .exe, but (at
 # least appveyor) adds .PY to $PATHEXT. So "trial wormhole" might work on
@@ -38,7 +39,6 @@ deps =
     pyflakes >= 1.2.3
     mock
     coverage
-    {env:EXTRA_DEPENDENCY:}
 commands =
     pyflakes setup.py src
     wormhole --version


### PR DESCRIPTION
This PR adds support for pep508 and removes the requirement for the `[windows]` extra to properly install on windows.

It also (finally) fixes the appveyor builds so that they run trial correctly. I'm not particularly happy about hard coding the `python src/wormhole/test/run_trial.py` call, but the behavior of -m is different between python 2 and 3 and this is the only way I could get it to work cross platform/version.

I can squash these commits for down for cleanliness if you want.