### PR TITLE
Unicode literals

### DIFF
--- a/src/wormhole/_version.py
+++ b/src/wormhole/_version.py
@@ -1,4 +1,4 @@
-
+from __future__ import unicode_literals
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build

--- a/src/wormhole/channel_monitor.py
+++ b/src/wormhole/channel_monitor.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import sys
 from weakref import ref
 

--- a/src/wormhole/codes.py
+++ b/src/wormhole/codes.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import os, six
 from .wordlist import (byte_to_even_word, byte_to_odd_word,
                        even_words_lowercase, odd_words_lowercase)

--- a/src/wormhole/errors.py
+++ b/src/wormhole/errors.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import functools
 
 class ServerError(Exception):

--- a/src/wormhole/ipaddrs.py
+++ b/src/wormhole/ipaddrs.py
@@ -1,4 +1,4 @@
-
+# no unicode_literals
 # Find all of our ip addresses. From tahoe's src/allmydata/util/iputil.py
 
 import os, re, subprocess, errno

--- a/src/wormhole/server/cmd_server.py
+++ b/src/wormhole/server/cmd_server.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import os, time
 from twisted.python import usage
 from twisted.scripts import twistd

--- a/src/wormhole/server/cmd_usage.py
+++ b/src/wormhole/server/cmd_usage.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import os, time, json
 from collections import defaultdict
 from .database import get_db

--- a/src/wormhole/server/database.py
+++ b/src/wormhole/server/database.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os, sys
 import sqlite3
 from pkg_resources import resource_string
@@ -10,6 +11,13 @@ def get_schema(version):
                                    "db-schemas/v%d.sql" % version)
     return schema_bytes.decode("utf-8")
 
+
+def dict_factory(cursor, row):
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
 def get_db(dbfile, stderr=sys.stderr):
     """Open or create the given db file. The parent directory must exist.
     Returns the db connection object, or raises DBError.
@@ -20,7 +28,7 @@ def get_db(dbfile, stderr=sys.stderr):
         db = sqlite3.connect(dbfile)
     except (EnvironmentError, sqlite3.OperationalError) as e:
         raise DBError("Unable to create/open db file %s: %s" % (dbfile, e))
-    db.row_factory = sqlite3.Row
+    db.row_factory = dict_factory
 
     VERSION = 2
     if must_create:
@@ -30,7 +38,7 @@ def get_db(dbfile, stderr=sys.stderr):
         db.commit()
 
     try:
-        version = db.execute("SELECT version FROM version").fetchone()[0]
+        version = db.execute("SELECT version FROM version").fetchone()["version"]
     except sqlite3.DatabaseError as e:
         # this indicates that the file is not a compatible database format.
         # Perhaps it was created with an old version, or it might be junk.

--- a/src/wormhole/server/endpoint_service.py
+++ b/src/wormhole/server/endpoint_service.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from twisted.python import log
 from twisted.internet import defer
 from twisted.application import service

--- a/src/wormhole/server/rendezvous.py
+++ b/src/wormhole/server/rendezvous.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import os, time, random, base64
 from collections import namedtuple
 from twisted.python import log

--- a/src/wormhole/server/rendezvous_websocket.py
+++ b/src/wormhole/server/rendezvous_websocket.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import time
 from twisted.internet import reactor
 from twisted.python import log

--- a/src/wormhole/server/runner.py
+++ b/src/wormhole/server/runner.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import os, sys
 from .cli_args import parser
 

--- a/src/wormhole/server/server.py
+++ b/src/wormhole/server/server.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 from twisted.python import log
 from twisted.internet import reactor, endpoints
 from twisted.application import service

--- a/src/wormhole/server/transit_server.py
+++ b/src/wormhole/server/transit_server.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import re, time
 from twisted.python import log
 from twisted.internet import protocol

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -14,6 +14,8 @@ class ServerBase:
         self.sp.startService()
         relayport = allocate_tcp_port()
         transitport = allocate_tcp_port()
+        # need to talk to twisted team about only using unicode in
+        # endpoints.serverFromString
         s = RelayServer("tcp:%d:interface=127.0.0.1" % relayport,
                         "tcp:%s:interface=127.0.0.1" % transitport,
                         advertise_version=__version__,

--- a/src/wormhole/test/run_trial.py
+++ b/src/wormhole/test/run_trial.py
@@ -1,4 +1,4 @@
-
+from __future__ import unicode_literals
 # This is a tiny helper module, to let "python -m wormhole.test.run_trial
 # ARGS" does the same thing as running "trial ARGS" (unfortunately
 # twisted/scripts/trial.py does not have a '__name__=="__main__"' clause).

--- a/src/wormhole/test/test_hkdf.py
+++ b/src/wormhole/test/test_hkdf.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import unittest
 from binascii import unhexlify #, hexlify
 from hkdf import Hkdf
@@ -42,4 +42,3 @@ class TestKAT(unittest.TestCase):
 
 #if __name__ == '__main__':
 #    generate_KAT()
-

--- a/src/wormhole/test/test_scripts.py
+++ b/src/wormhole/test/test_scripts.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import os, sys, re, io, zipfile, six, stat
 import mock
 from twisted.trial import unittest

--- a/src/wormhole/test/test_server.py
+++ b/src/wormhole/test/test_server.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import json, itertools
 from binascii import hexlify
 import mock
@@ -375,9 +375,9 @@ class Prune(unittest.TestCase):
                     for messages in [None, OLD, NEW]:
                         self.one(nameplate, mailbox, has_listeners, messages)
 
-    #def test_one(self):
+    # def test_one(self):
     #    # to debug specific problems found by test_lots
-    #    self.one(None, "old", True, None)
+    #    self.one(None, "old", False, 'new')
 
     def one(self, nameplate, mailbox, has_listeners, messages):
         desc = ("nameplate=%s, mailbox=%s, has_listeners=%s,"
@@ -427,8 +427,8 @@ class Prune(unittest.TestCase):
             messages = None
             messages_survive = False
 
-        if (nameplate is NEW or mailbox is NEW
-            or has_listeners or messages is NEW):
+        if (nameplate == NEW or mailbox == NEW
+            or has_listeners or messages == NEW):
             if nameplate is not None:
                 nameplate_survives = True
             if mailbox is not None:

--- a/src/wormhole/test/test_transit.py
+++ b/src/wormhole/test/test_transit.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import io
 from binascii import hexlify, unhexlify
 from twisted.trial import unittest

--- a/src/wormhole/test/test_util.py
+++ b/src/wormhole/test/test_util.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unicodedata
 from twisted.trial import unittest
 from .. import util

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import os, json, re, gc
 from binascii import hexlify, unhexlify
 import mock

--- a/src/wormhole/timing.py
+++ b/src/wormhole/timing.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, absolute_import
+from __future__ import print_function, absolute_import, unicode_literals
 import json, time
 
 class Event:

--- a/src/wormhole/tor_manager.py
+++ b/src/wormhole/tor_manager.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import time
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.error import ConnectError

--- a/src/wormhole/transit.py
+++ b/src/wormhole/transit.py
@@ -1,3 +1,4 @@
+# no unicode_literals, revisit after twisted patch
 from __future__ import print_function, absolute_import
 import re, sys, time, socket
 from collections import namedtuple, deque

--- a/src/wormhole/wordlist.py
+++ b/src/wormhole/wordlist.py
@@ -1,4 +1,4 @@
-
+from __future__ import unicode_literals
 # The PGP Word List, which maps bytes to phonetically-distinct words. There
 # are two lists, even and odd, and encodings should alternate between then to
 # detect dropped words. https://en.wikipedia.org/wiki/PGP_Words

--- a/src/wormhole/wormhole.py
+++ b/src/wormhole/wormhole.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, absolute_import
+from __future__ import print_function, absolute_import, unicode_literals
 import os, sys, re
 from six.moves.urllib_parse import urlparse
 from twisted.internet import defer, endpoints, error


### PR DESCRIPTION
addressing issue #30, I've added the `__future__ import unicode_literals` to all modules that can handle it. I'm going to go through the modules removing explicit `u""` and getting more fine toothed with it.

I submitted a [PR](https://github.com/twisted/twisted/pull/141) to Twisted that should let us have full unicode adoption outside the CLI. Once it gets merged and released I'll update the requirements and fix the remaining modules.