### PR TITLE
Issue29: notification on slow verification

### DIFF
--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -69,7 +69,16 @@ class TwistedReceiver:
     @inlineCallbacks
     def _go(self, w):
         yield self._handle_code(w)
-        verifier = yield w.verify()
+        yield w.establish_key()
+        def on_slow_connection():
+            print(u"Key established, waiting for confirmation...",
+                  file=self.args.stdout)
+        notify = self._reactor.callLater(1, on_slow_connection)
+        try:
+            verifier = yield w.verify()
+        finally:
+            if not notify.called:
+                notify.cancel()
         self._show_verifier(verifier)
 
         want_offer = True

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -10,6 +10,7 @@ from ..errors import TransferError, WormholeClosedError
 from ..util import dict_to_bytes, bytes_to_dict, bytes_to_hexstr
 
 APPID = u"lothar.com/wormhole/text-or-file-xfer"
+VERIFY_TIMER = 1
 
 class RespondError(Exception):
     def __init__(self, response):
@@ -72,8 +73,8 @@ class TwistedReceiver:
         yield w.establish_key()
         def on_slow_connection():
             print(u"Key established, waiting for confirmation...",
-                  file=self.args.stdout)
-        notify = self._reactor.callLater(1, on_slow_connection)
+                  file=self.args.stderr)
+        notify = self._reactor.callLater(VERIFY_TIMER, on_slow_connection)
         try:
             verifier = yield w.verify()
         finally:

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -11,6 +11,7 @@ from ..transit import TransitSender
 from ..util import dict_to_bytes, bytes_to_dict, bytes_to_hexstr
 
 APPID = u"lothar.com/wormhole/text-or-file-xfer"
+VERIFY_TIMER = 1
 
 def send(args, reactor=reactor):
     """I implement 'wormhole send'. I return a Deferred that fires with None
@@ -87,8 +88,8 @@ class Sender:
         yield w.establish_key()
         def on_slow_connection():
             print(u"Key established, waiting for confirmation...",
-                  file=args.stdout)
-        notify = self._reactor.callLater(1, on_slow_connection)
+                  file=args.stderr)
+        notify = self._reactor.callLater(VERIFY_TIMER, on_slow_connection)
 
         # TODO: don't stall on w.verify() unless they want it
         try:

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -84,6 +84,9 @@ class Sender:
             print(u"Wormhole code is: %s" % code, file=args.stdout)
         print(u"", file=args.stdout)
 
+        key_established = yield w.establish_key()
+        print(u"Key established, waiting for confirmation...")
+
         # TODO: don't stall on w.verify() unless they want it
         verifier_bytes = yield w.verify() # this may raise WrongPasswordError
         if args.verify:

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -85,7 +85,8 @@ class Sender:
         print(u"", file=args.stdout)
 
         key_established = yield w.establish_key()
-        print(u"Key established, waiting for confirmation...")
+        print(u"Key established, waiting for confirmation...",
+              file=args.stdout)
 
         # TODO: don't stall on w.verify() unless they want it
         verifier_bytes = yield w.verify() # this may raise WrongPasswordError

--- a/src/wormhole/test/test_scripts.py
+++ b/src/wormhole/test/test_scripts.py
@@ -225,8 +225,8 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
     def _do_test(self, as_subprocess=False,
                  mode="text", addslash=False, override_filename=False):
         assert mode in ("text", "file", "directory", "slow")
-        send_cfg = Config()
-        recv_cfg = Config()
+        send_cfg = config("send")
+        recv_cfg = config("receive")
         message = "blah blah blah ponies"
 
         for cfg in [send_cfg, recv_cfg]:

--- a/src/wormhole/test/test_scripts.py
+++ b/src/wormhole/test/test_scripts.py
@@ -224,9 +224,9 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
     @inlineCallbacks
     def _do_test(self, as_subprocess=False,
                  mode="text", addslash=False, override_filename=False):
-        assert mode in ("text", "file", "directory")
-        send_cfg = config("send")
-        recv_cfg = config("receive")
+        assert mode in ("text", "file", "directory", "slow")
+        send_cfg = Config()
+        recv_cfg = Config()
         message = "blah blah blah ponies"
 
         for cfg in [send_cfg, recv_cfg]:
@@ -243,7 +243,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
         receive_dir = self.mktemp()
         os.mkdir(receive_dir)
 
-        if mode == "text":
+        if mode == "text" or mode == "slow":
             send_cfg.text = message
 
         elif mode == "file":
@@ -347,8 +347,14 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
 
             # The sender might fail, leaving the receiver hanging, or vice
             # versa. Make sure we don't wait on one side exclusively
+            if mode == "slow":
+                with mock.patch.object(cmd_send, "VERIFY_TIMER", 0), \
+                      mock.patch.object(cmd_receive, "VERIFY_TIMER", 0):
+                    yield gatherResults([send_d, receive_d], True)
+            else:
+                yield gatherResults([send_d, receive_d], True)
 
-            yield gatherResults([send_d, receive_d], True)
+
             send_stdout = send_cfg.stdout.getvalue()
             send_stderr = send_cfg.stderr.getvalue()
             receive_stdout = recv_cfg.stdout.getvalue()
@@ -360,13 +366,21 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
 
         self.maxDiff = None # show full output for assertion failures
 
-        self.failUnlessEqual(send_stderr, "",
-                             (send_stdout, send_stderr))
-        self.failUnlessEqual(receive_stderr, "",
-                             (receive_stdout, receive_stderr))
+        if mode != "slow":
+            self.failUnlessEqual(send_stderr, "",
+                                 (send_stdout, send_stderr))
+            self.failUnlessEqual(receive_stderr, "",
+                                 (receive_stdout, receive_stderr))
+        else:
+            self.assertEqual(send_stderr,
+                "Key established, waiting for confirmation...\n",
+                (send_stdout, send_stderr))
+            self.assertEqual(receive_stderr,
+                "Key established, waiting for confirmation...\n",
+                (receive_stdout, receive_stderr))
 
         # check sender
-        if mode == "text":
+        if mode == "text" or mode == "slow":
             expected = ("Sending text message ({bytes:d} bytes){NL}"
                         "On the other computer, please run: "
                         "wormhole receive{NL}"
@@ -399,7 +413,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
                               .format(NL=NL), send_stdout)
 
         # check receiver
-        if mode == "text":
+        if mode == "text" or mode == "slow":
             self.failUnlessEqual(receive_stdout, message+NL)
         elif mode == "file":
             self.failUnlessIn("Receiving file ({bytes:d} bytes) into: {name}"
@@ -445,6 +459,9 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
         return self._do_test(mode="directory", addslash=True)
     def test_directory_override(self):
         return self._do_test(mode="directory", override_filename=True)
+
+    def test_slow(self):
+        return self._do_test(mode="slow")
 
     @inlineCallbacks
     def test_file_noclobber(self):

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -522,6 +522,32 @@ class Basic(unittest.TestCase):
         self.assertEqual(len(pieces), 3) # nameplate plus two words
         self.assert_(re.search(r'^\d+-\w+-\w+$', code), code)
 
+    def _test_establish_key_hook(self, established):
+
+        timing = DebugTiming()
+        w = wormhole._Wormhole(APPID, "relay_url", reactor, None, timing)
+
+        if established is True:
+            w._key = b"key"
+        elif established is False:
+            w._key = None
+        else:
+            w._key = b"key"
+            w._error = WelcomeError()
+
+        d = w.establish_key()
+
+        if w._key is not None and established is True:
+            self.successResultOf(d)
+        elif established is False:
+            self.assertNot(d.called)
+        else:
+            self.failureResultOf(d)
+
+    def test_establish_key_hook(self):
+        for established in (True, False, "error"):
+            self._test_establish_key_hook(established)
+
     # make sure verify() can be called both before and after the verifier is
     # computed
 

--- a/src/wormhole/wormhole.py
+++ b/src/wormhole/wormhole.py
@@ -289,7 +289,6 @@ class _Wormhole:
         returns a Deferred that fires when we've established the shared key.
         When successful, the Deferred fires with a simple `True`, otherwise
         it fails.
-
         """
         return self._API_establish_key()
 
@@ -582,7 +581,7 @@ class _Wormhole:
 
     def _API_establish_key(self):
         if self._error: return defer.fail(self._error)
-        if not self._key is None:
+        if self._key is not None:
             return defer.succeed(True)
         self._key_waiter = defer.Deferred()
         return self._key_waiter

--- a/src/wormhole/wormhole.py
+++ b/src/wormhole/wormhole.py
@@ -289,7 +289,7 @@ class _Wormhole:
         returns a Deferred that fires when we've established the shared key.
         When successful, the Deferred fires with a simple `True`, otherwise
         it fails.
-        
+
         """
         return self._API_establish_key()
 
@@ -852,6 +852,9 @@ class _Wormhole:
         if self._verifier_waiter and not self._verifier_waiter.called:
             if self.DEBUG: print("EB VW")
             self._verifier_waiter.errback(error)
+        if self._key_waiter and not self._key_waiter.called:
+            if self.DEBUG: print("EB KW")
+            self._key_waiter.errback(error)
         for d in self._receive_waiters.values():
             if self.DEBUG: print("EB RW")
             d.errback(error)


### PR DESCRIPTION
This branch should close #29 as it was described.

~~I tried to write a test for the scripts, but I couldn't monkey patch wormhole to slow it down without refactoring the script import structure completely. when manually testing I just put a sleep in the verification step.~~  Figured out a test after realizing I'm an idiot. I also put the message to stderr to keep piping clean.

I'm also not wild about the API verb `exchange_key` so let me know if you've got something better.
