### PR TITLE
unit-test for relay request, and fix Data() handling

### DIFF
--- a/src/wormhole/server/server.py
+++ b/src/wormhole/server/server.py
@@ -1,4 +1,6 @@
-from __future__ import print_function, unicode_literals
+# NO unicode_literals or static.Data() will break, because it demands
+# a str on Python 2
+from __future__ import print_function
 from twisted.python import log
 from twisted.internet import reactor, endpoints
 from twisted.application import service

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -13,21 +13,21 @@ class ServerBase:
     def _setup_relay(self, error):
         self.sp = service.MultiService()
         self.sp.startService()
-        relayport = allocate_tcp_port()
-        transitport = allocate_tcp_port()
+        self.relayport = allocate_tcp_port()
+        self.transitport = allocate_tcp_port()
         # need to talk to twisted team about only using unicode in
         # endpoints.serverFromString
-        s = RelayServer("tcp:%d:interface=127.0.0.1" % relayport,
-                        "tcp:%s:interface=127.0.0.1" % transitport,
+        s = RelayServer("tcp:%d:interface=127.0.0.1" % self.relayport,
+                        "tcp:%s:interface=127.0.0.1" % self.transitport,
                         advertise_version=__version__,
                         signal_error=error)
         s.setServiceParent(self.sp)
         self._rendezvous = s._rendezvous
         self._transit_server = s._transit
-        self.relayurl = u"ws://127.0.0.1:%d/v1" % relayport
-        self.rdv_ws_port = relayport
+        self.relayurl = u"ws://127.0.0.1:%d/v1" % self.relayport
+        self.rdv_ws_port = self.relayport
         # ws://127.0.0.1:%d/wormhole-relay/ws
-        self.transit = u"tcp:127.0.0.1:%d" % transitport
+        self.transit = u"tcp:127.0.0.1:%d" % self.transitport
 
     def tearDown(self):
         # Unit tests that spawn a (blocking) client in a thread might still

--- a/src/wormhole/test/test_server.py
+++ b/src/wormhole/test/test_server.py
@@ -7,6 +7,7 @@ from twisted.python import log
 from twisted.internet import protocol, reactor, defer
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.endpoints import clientFromString, connectProtocol
+from twisted.web import client
 from autobahn.twisted import websocket
 from .. import __version__
 from .common import ServerBase
@@ -1029,6 +1030,11 @@ class Transit(ServerBase, unittest.TestCase):
         self.failUnlessEqual(blur(1050e6), 1100e6)
         self.failUnlessEqual(blur(1100e6), 1100e6)
         self.failUnlessEqual(blur(1150e6), 1200e6)
+
+    @defer.inlineCallbacks
+    def test_web_request(self):
+        resp = yield client.getPage('http://127.0.0.1:{}/'.format(self.relayport).encode('ascii'))
+        self.assertEqual('Wormhole Relay'.encode('ascii'), resp.strip())
 
     @defer.inlineCallbacks
     def test_basic(self):


### PR DESCRIPTION
Pulled out of click-refactor. The reason this issue didn't come up with the unicode_literals changes is because there wasn't a test that just accessed the relay-server, so I added one for that too.