### PR TITLE
help bad spelers

### DIFF
--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -41,6 +41,8 @@ def _compose(*decorators):
 ALIASES = {
     "tx": "send",
     "rx": "receive",
+    "recieve": "receive",
+    "recv": "receive",
 }
 class AliasedGroup(click.Group):
     def get_command(self, ctx, cmd_name):


### PR DESCRIPTION
Some of us can never remember the old ditty:

   i before e, except after c
   or when sounding like "a"
   as in neighbor or weigh.

Perhaps magic wormhole can coddle us in our misorthography :)