### PR TITLE
Fix small CLI typo

### DIFF
--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -65,7 +65,7 @@ class Sender:
 
         other_cmd = "wormhole receive"
         if args.verify:
-            other_cmd = "wormhole --verify receive"
+            other_cmd = "wormhole receive --verify"
         if args.zeromode:
             assert not args.code
             args.code = u"0-"


### PR DESCRIPTION
The output for verified copies asks the user to run `wormhole --verify receive`, but the correct argument order is `wormhole receive --verify`.