### PR TITLE
send: flush stdout after displaying code

### DIFF
--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -84,6 +84,8 @@ class Sender:
 
         if not args.zeromode:
             print(u"Wormhole code is: %s" % code, file=args.stdout)
+            # flush stdout so the code is displayed immediately
+            sys.stdout.flush()
         print(u"", file=args.stdout)
 
         yield w.establish_key()


### PR DESCRIPTION
Fixes https://github.com/warner/magic-wormhole/issues/108

Apparently python defaults to buffering stdout when not outputting to
the terminal. It would be better IMHO if every line of stdout were
autoflushed, but based on
http://stackoverflow.com/questions/107705/disable-output-buffering
there's not a really good way to accomplish that in python.