### PR TITLE
Add --appid to override the APPID, for subprocess-based wrappers.

### DIFF
--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -55,6 +55,8 @@ class AliasedGroup(click.Group):
 # top-level command ("wormhole ...")
 @click.group(cls=AliasedGroup)
 @click.option(
+    "--appid", default=None, metavar="APPID", help="appid to use")
+@click.option(
     "--relay-url", default=public_relay.RENDEZVOUS_RELAY,
     metavar="URL",
     help="rendezvous relay to use",
@@ -75,7 +77,7 @@ class AliasedGroup(click.Group):
     version=__version__,
 )
 @click.pass_context
-def wormhole(context, dump_timing, transit_helper, relay_url):
+def wormhole(context, dump_timing, transit_helper, relay_url, appid):
     """
     Create a Magic Wormhole and communicate through it.
 
@@ -84,6 +86,7 @@ def wormhole(context, dump_timing, transit_helper, relay_url):
     anyone who doesn't use the same code.
     """
     context.obj = cfg = Config()
+    cfg.appid = appid
     cfg.relay_url = relay_url
     cfg.transit_helper = transit_helper
     cfg.dump_timing = dump_timing

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -57,8 +57,8 @@ class TwistedReceiver:
             # with the user handing off the wormhole code
             yield self._tor_manager.start()
 
-        w = wormhole(APPID, self.args.relay_url, self._reactor,
-                     self._tor_manager, timing=self.args.timing)
+        w = wormhole(self.args.appid or APPID, self.args.relay_url,
+                     self._reactor, self._tor_manager, timing=self.args.timing)
         # I wanted to do this instead:
         #
         #    try:

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -47,7 +47,7 @@ class Sender:
             # with the user handing off the wormhole code
             yield self._tor_manager.start()
 
-        w = wormhole(APPID, self._args.relay_url,
+        w = wormhole(self._args.appid or APPID, self._args.relay_url,
                      self._reactor, self._tor_manager,
                      timing=self._timing)
         d = self._go(w)

--- a/src/wormhole/cli/cmd_ssh.py
+++ b/src/wormhole/cli/cmd_ssh.py
@@ -63,7 +63,7 @@ def find_public_key(hint=None):
 def accept(cfg, reactor=reactor):
     yield xfer_util.send(
         reactor,
-        u"lothar.com/wormhole/ssh-add",
+        cfg.appid or u"lothar.com/wormhole/ssh-add",
         cfg.relay_url,
         data=cfg.public_key[2],
         code=cfg.code,
@@ -104,7 +104,7 @@ def invite(cfg, reactor=reactor):
 
     pubkey = yield xfer_util.receive(
         reactor,
-        u"lothar.com/wormhole/ssh-add",
+        cfg.appid or u"lothar.com/wormhole/ssh-add",
         cfg.relay_url,
         None,  # allocate a code for us
         use_tor=cfg.tor,

--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -14,12 +14,19 @@ class Send(unittest.TestCase):
         self.assertEqual(cfg.dump_timing, None)
         self.assertEqual(cfg.hide_progress, False)
         self.assertEqual(cfg.listen, True)
+        self.assertEqual(cfg.appid, None)
         self.assertEqual(cfg.relay_url, RENDEZVOUS_RELAY)
         self.assertEqual(cfg.transit_helper, TRANSIT_RELAY)
         self.assertEqual(cfg.text, "hi")
         self.assertEqual(cfg.tor, False)
         self.assertEqual(cfg.verify, False)
         self.assertEqual(cfg.zeromode, False)
+
+    def test_appid(self):
+        cfg = config("--appid", "xyz", "send", "--text", "hi")
+        self.assertEqual(cfg.appid, "xyz")
+        cfg = config("--appid=xyz", "send", "--text", "hi")
+        self.assertEqual(cfg.appid, "xyz")
 
     def test_file(self):
         cfg = config("send", "fn")
@@ -76,11 +83,18 @@ class Receive(unittest.TestCase):
         self.assertEqual(cfg.listen, True)
         self.assertEqual(cfg.only_text, False)
         self.assertEqual(cfg.output_file, None)
+        self.assertEqual(cfg.appid, None)
         self.assertEqual(cfg.relay_url, RENDEZVOUS_RELAY)
         self.assertEqual(cfg.transit_helper, TRANSIT_RELAY)
         self.assertEqual(cfg.tor, False)
         self.assertEqual(cfg.verify, False)
         self.assertEqual(cfg.zeromode, False)
+
+    def test_appid(self):
+        cfg = config("--appid", "xyz", "receive")
+        self.assertEqual(cfg.appid, "xyz")
+        cfg = config("--appid=xyz", "receive")
+        self.assertEqual(cfg.appid, "xyz")
 
     def test_nolisten(self):
         cfg = config("receive", "--no-listen")


### PR DESCRIPTION
Tools which use `wormhole send` under the hood should use a distinct
--appid= (setting the same URL-shaped value on both sides, starting with a
domain name related to the tool and/or its author), so wormhole codes used by
those tools won't compete for short channelids with other tools, or the
default text/file/directory-sending tool.

Closes #113