### PR TITLE
turn on python3.6 builds for tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6-dev"
 install:
   - pip install -U pip tox virtualenv codecov
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py27,py33,py34,py35,pypy}
+envlist = {py27,py33,py34,py35,py36,pypy}
 skip_missing_interpreters = True
 
 # On windows we need "pypiwin32" installed. It's supposedly possible to make


### PR DESCRIPTION
Python3.6 was just released a few days ago, and travis hasn't yet added it
for real, so we use "3.6-dev" until they get it deployed completely.