### PR TITLE
Make footnotes section an HTML comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,6 @@ is probably compatible with py2.6, but the latest Twisted (>=15.5.0) is
 not.
 
 
-#### footnotes
+<!-- footnotes -->
 
 [1]: http://www.di.ens.fr/~pointche/Documents/Papers/2005_rsa.pdf "RSA 2005"


### PR DESCRIPTION
I noticed that the footnotes section appears as a visible heading when rendered as HTML (e.g. in GitHub), which looks odd because there's nothing below it, so I thought it might be useful to wrap it in an HTML comment so it's only seen by those who view it in its text form.  Feel free to close this PR if you disagree though!