### PR TITLE
Dockerfile to build a magic-wormhole server image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.appveyor.yml
+.coveragerc
+docs
+.git
+.gitattributes
+.gitignore
+misc
+snapcraft.yaml
+tox.ini
+.travis.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+#
+# Attempts are made to follow the guidelines at
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/
+#
+
+FROM library/ubuntu:16.04
+
+# If there are security updates for any of the packages we install,
+# bump the date in this environment variable to invalidate the Docker
+# build cache and force installation of the new packages.  Otherwise,
+# Docker's image/layer cache may prevent the security update from
+# being retrieved.
+ENV SECURITY_UPDATES="2017-15-01"
+
+# Tell apt/dpkg/debconf that we're non-interactive so it won't write
+# annoying warnings as it installs the software we ask for.  Making
+# this an `ARG` sets it in the environment for the duration of the
+# _build_ only - preventing this from having any effect on a container
+# running this image (which shouldn't really be installing more
+# software but who knows...).
+ARG DEBIAN_FRONTEND=noninteractive
+
+# We'll do an upgrade because the base Ubuntu image isn't guaranteed
+# to include the latest security updates.  This is counter to best
+# practice recommendations but security updates are important.
+RUN apt-get --quiet update && \
+    apt-get --quiet install -y unattended-upgrades && \
+    unattended-upgrade --minimal_upgrade_steps && \
+rm -rf /var/lib/apt/lists/*
+
+RUN apt-get --quiet update && apt-get --quiet install -y \
+    python-dev \
+    libffi-dev \
+    openssl \
+    libssl-dev \
+    \
+    python-virtualenv \
+&& rm -rf /var/lib/apt/lists/*
+
+# Create a virtualenv into which to install magicwormhole in to.
+RUN virtualenv /app/env
+
+# Get a newer version of pip.
+RUN /app/env/bin/pip install --upgrade pip
+
+# Create the website account, the user as which the infrastructure
+# server will run.
+ENV WORMHOLE_USER_NAME="wormhole"
+
+# Force the allocated user to uid 1000 because we hard-code 1000
+# below.
+RUN adduser --uid 1000 --disabled-password --gecos "" "${WORMHOLE_USER_NAME}"
+
+# Run the application with this working directory.
+WORKDIR /app/run
+
+# And give it to the user the application will run as.
+RUN chown ${WORMHOLE_USER_NAME} /app/run
+
+# Facilitate network connections to the application.
+EXPOSE 4000
+
+# Put the source somewhere pip will be able to see it.
+ADD . /src
+
+# Get the app we want to run!
+RUN /app/env/bin/pip install /src
+
+# Switch to a non-root user.
+USER 1000
+
+CMD /app/env/bin/wormhole-server start \
+    --rendezvous tcp:4000 \
+    --no-daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN apt-get --quiet update && apt-get --quiet install -y \
     python-virtualenv \
 && rm -rf /var/lib/apt/lists/*
 
+# Source repositories seem to be disabled on the Xenial image now.  Enable
+# them so we can actually get some build deps.
+RUN sed -i -e 's/^# deb-src/deb-src/' /etc/apt/sources.list
+
 # magic-wormhole depends on these and pip wants to build them both from
 # source.
 RUN apt-get --quiet update && apt-get --quiet build-dep -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get --quiet update && \
 rm -rf /var/lib/apt/lists/*
 
 RUN apt-get --quiet update && apt-get --quiet install -y \
+    gcc \
     python-dev \
     libffi-dev \
     openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get --quiet update && apt-get --quiet install -y \
 # magic-wormhole depends on these and pip wants to build them both from
 # source.
 RUN apt-get --quiet update && apt-get --quiet build-dep -y \
-    pyopenssl \
+    python-openssl \
     python-nacl \
 && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,15 +49,14 @@ RUN apt-get --quiet update && apt-get --quiet build-dep -y \
 # Create a virtualenv into which to install magicwormhole in to.
 RUN virtualenv /app/env
 
-# Get a newer version of pip.
+# Get a newer version of pip.  The version in the virtualenv installed from
+# Ubuntu might not be very recent, depending on when the build happens.
 RUN /app/env/bin/pip install --upgrade pip
 
-# Create the website account, the user as which the infrastructure
-# server will run.
+# Create a less privileged account to actually use to run the server.
 ENV WORMHOLE_USER_NAME="wormhole"
 
-# Force the allocated user to uid 1000 because we hard-code 1000
-# below.
+# Force the allocated user to uid 1000 because we hard-code 1000 below.
 RUN adduser --uid 1000 --disabled-password --gecos "" "${WORMHOLE_USER_NAME}"
 
 # Run the application with this working directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,12 @@ RUN apt-get --quiet update && \
 rm -rf /var/lib/apt/lists/*
 
 RUN apt-get --quiet update && apt-get --quiet install -y \
-    gcc \
-    python-dev \
-    libffi-dev \
-    openssl \
-    libssl-dev \
-    \
     python-virtualenv \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN apt-get --quiet update && apt-get --quiet build-dep -y \
+    python-nacl \
+    python-openssl \
 && rm -rf /var/lib/apt/lists/*
 
 # Create a virtualenv into which to install magicwormhole in to.

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN apt-get --quiet update && apt-get --quiet install -y \
 # magic-wormhole depends on these and pip wants to build them both from
 # source.
 RUN apt-get --quiet update && apt-get --quiet build-dep -y \
+    pyopenssl \
     python-nacl \
-    python-openssl \
 && rm -rf /var/lib/apt/lists/*
 
 # Create a virtualenv into which to install magicwormhole in to.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,15 @@ RUN apt-get --quiet update && \
     unattended-upgrade --minimal_upgrade_steps && \
 rm -rf /var/lib/apt/lists/*
 
+# libffi-dev should probably be a build-dep for python-nacl and python-openssl
+# but isn't for some reason.
 RUN apt-get --quiet update && apt-get --quiet install -y \
+    libffi-dev \
     python-virtualenv \
 && rm -rf /var/lib/apt/lists/*
 
+# magic-wormhole depends on these and pip wants to build them both from
+# source.
 RUN apt-get --quiet update && apt-get --quiet build-dep -y \
     python-nacl \
     python-openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,10 @@ WORKDIR /app/run
 # And give it to the user the application will run as.
 RUN chown ${WORMHOLE_USER_NAME} /app/run
 
-# Facilitate network connections to the application.
+# Facilitate network connections to the application.  The rendezvous server
+# listens on 4000 by default.  The transit relay server on 4001.
 EXPOSE 4000
+EXPOSE 4001
 
 # Put the source somewhere pip will be able to see it.
 ADD . /src
@@ -78,6 +80,9 @@ RUN /app/env/bin/pip install /src
 # Switch to a non-root user.
 USER 1000
 
-CMD /app/env/bin/wormhole-server start \
-    --rendezvous tcp:4000 \
-    --no-daemon
+# This makes starting a server succinct.
+ENTRYPOINT ["/app/env/bin/wormhole-server", "start", "--no-daemon"]
+
+# By default, start up a pretty reasonable server.  This can easily be
+# overridden by another command which will get added to the entrypoint.
+CMD ["--rendezvous", "tcp:4000", "--transit", "tcp:4001"]


### PR DESCRIPTION
This adds a Dockerfile to the top of the repo.  The Dockerfile produces an image which can very simply be used to run a magic-wormhole server.  I haven't attempted to make this usable for the client side of things.  It might make sense to have a separate image to facilitate client operation but let's leave that aside for now.

After building this image locally:

```
$ docker run --rm 14e0d30f83cb 
starting wormhole relay server
2017-05-02T13:12:59+0000 [-] populating new database with schema v3
2017-05-02T13:13:00+0000 [twisted.scripts._twistd_unix.UnixAppLogger#info] twistd 17.1.0 (/app/env/bin/python2 2.7.12) starting up.
2017-05-02T13:13:00+0000 [twisted.scripts._twistd_unix.UnixAppLogger#info] reactor class: twisted.internet.epollreactor.EPollReactor.
2017-05-02T13:13:00+0000 [-] PrivacyEnhancedSite starting on 4000
2017-05-02T13:13:00+0000 [wormhole.server.server.PrivacyEnhancedSite#info] Starting factory <wormhole.server.server.PrivacyEnhancedSite instance at 0x7f3f83369dd0>
2017-05-02T13:13:00+0000 [-] Transit starting on 4001
2017-05-02T13:13:00+0000 [wormhole.server.transit_server.Transit#info] Starting factory <wormhole.server.transit_server.Transit object at 0x7f3f8336cdd0>
2017-05-02T13:13:00+0000 [-] beginning app prune
2017-05-02T13:13:00+0000 [-] app prune ends, 0 apps
2017-05-02T13:13:00+0000 [-] get_stats took: 0.0419459342957
2017-05-02T13:13:00+0000 [-] websocket listening on /wormhole-relay/ws
2017-05-02T13:13:00+0000 [-] Wormhole relay server (Rendezvous and Transit) running
2017-05-02T13:13:00+0000 [-] not blurring access times
^C2017-05-02T13:13:02+0000 [-] Received SIGINT, shutting down.
2017-05-02T13:13:02+0000 [-] (TCP Port 4001 Closed)
2017-05-02T13:13:02+0000 [wormhole.server.transit_server.Transit#info] Stopping factory <wormhole.server.transit_server.Transit object at 0x7f3f8336cdd0>
2017-05-02T13:13:02+0000 [-] (TCP Port 4000 Closed)
2017-05-02T13:13:02+0000 [wormhole.server.server.PrivacyEnhancedSite#info] Stopping factory <wormhole.server.server.PrivacyEnhancedSite instance at 0x7f3f83369dd0>
2017-05-02T13:13:02+0000 [-] Main loop terminated.
2017-05-02T13:13:02+0000 [twisted.scripts._twistd_unix.UnixAppLogger#info] Server Shut Down.
```

Also, I have managed to set up Docker Hub automated builds for the LeastAuthority fork so we can see this will also build successfully there:

    https://hub.docker.com/r/leastauthority/magic-wormhole/

And I would like to set up something similar pointing at github.com/warner/magic-wormhole once this is merged.

Also, please pay no attention to the branch name.  Initially it appeared that quay.io was a more attractive continuous-build platform than Docker Hub but upon learning more I see it's essentially the same or *perhaps* slightly worse from a security perspective.