### PR TITLE
Add an "--ignore-unsendable-files" flag

### DIFF
--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -10,7 +10,7 @@ from . import public_relay
 from .. import __version__
 from ..timing import DebugTiming
 from ..errors import (WrongPasswordError, WelcomeError, KeyFormatError,
-                      TransferError, NoTorError)
+                      TransferError, NoTorError, UnsendableFileError)
 from twisted.internet.defer import inlineCallbacks, maybeDeferred
 from twisted.python.failure import Failure
 from twisted.internet.task import react
@@ -109,7 +109,7 @@ def _dispatch_command(reactor, cfg, command):
         msg = fill("ERROR: " + dedent(e.__doc__))
         print(msg, file=cfg.stderr)
         raise SystemExit(1)
-    except WelcomeError as e:
+    except (WelcomeError, UnsendableFileError) as e:
         msg = fill("ERROR: " + dedent(e.__doc__))
         print(msg, file=cfg.stderr)
         print(six.u(""), file=cfg.stderr)
@@ -172,6 +172,10 @@ TorArgs = _compose(
 @click.option(
     "--text", default=None, metavar="MESSAGE",
     help="text message to send, instead of a file. Use '-' to read from stdin.",
+)
+@click.option(
+    "--ignore-unsendable-files", default=False, is_flag=True,
+    help="Don't raise an error if a file can't be read."
 )
 @click.argument("what", required=False)
 @click.pass_obj

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -282,7 +282,8 @@ class Sender:
                         except OSError as e:
                             errmsg = u"{}: {}".format(fn, e.strerror)
                             if self._args.ignore_unsendable_files:
-                                print(u"{} (ignoring error)".format(errmsg))
+                                print(u"{} (ignoring error)".format(errmsg),
+                                      file=args.stderr)
                             else:
                                 raise UnsendableFileError(errmsg)
             fd_to_send.seek(0,2)

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -6,7 +6,8 @@ from twisted.python import log
 from twisted.protocols import basic
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
-from ..errors import TransferError, WormholeClosedError, NoTorError
+from ..errors import (TransferError, WormholeClosedError, NoTorError,
+                      UnsendableFileError)
 from wormhole import create, __version__
 from ..transit import TransitSender
 from ..util import dict_to_bytes, bytes_to_dict, bytes_to_hexstr
@@ -274,9 +275,16 @@ class Sender:
                     for fn in files:
                         archivename = os.path.join(*tuple(localpath+[fn]))
                         localfilename = os.path.join(path, fn)
-                        zf.write(localfilename, archivename)
-                        num_bytes += os.stat(localfilename).st_size
-                        num_files += 1
+                        try:
+                            zf.write(localfilename, archivename)
+                            num_bytes += os.stat(localfilename).st_size
+                            num_files += 1
+                        except OSError as e:
+                            errmsg = u"{}: {}".format(fn, e.strerror)
+                            if self._args.ignore_unsendable_files:
+                                print(u"{} (ignoring error)".format(errmsg))
+                            else:
+                                raise UnsendableFileError(errmsg)
             fd_to_send.seek(0,2)
             filesize = fd_to_send.tell()
             fd_to_send.seek(0,0)

--- a/src/wormhole/errors.py
+++ b/src/wormhole/errors.py
@@ -3,6 +3,16 @@ from __future__ import unicode_literals
 class WormholeError(Exception):
     """Parent class for all wormhole-related errors"""
 
+class UnsendableFileError(Exception):
+    """
+    A file you wanted to send couldn't be read, maybe because it's not
+    a file, or because it's a symlink that points to something
+    that doesn't exist.
+
+    To ignore this kind of error, you can run wormhole with the
+    --ignore-unsendable-files flag.
+    """
+
 class ServerError(WormholeError):
     """The relay server complained about something we did."""
 

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -85,7 +85,12 @@ class OfferData(unittest.TestCase):
         self._create_broken_symlink()
         self.cfg.ignore_unsendable_files = False
         e = self.assertRaises(UnsendableFileError, build_offer, self.cfg)
-        self.assertEqual(str(e), "linky: No such file or directory")
+
+        # On english distributions of Linux, this will be
+        # "linky: No such file or directory", but the error may be
+        # different on Windows and other locales and/or Unix variants, so
+        # we'll just assert the part we know about.
+        self.assertIn("linky: ", str(e))
 
     def test_broken_symlink_is_ignored(self):
         self._create_broken_symlink()


### PR DESCRIPTION
This is a **work-in-progress** attempt to fix #112 by:

* Making unreadable file errors more human-friendly;
* Adding an `--ignore-unsendable-files` flag that ignores such errors.

## Examples

Here's what it looks like if we send a directory called `breakage` with a broken symlink called `blap` in it:

```
$ wormhole send breakage
Building zipfile..
ERROR:  A file you wanted to send couldn't be read, maybe because it's
not a file, or because it's a symlink that points to something that
doesn't exist.  To ignore this kind of error, you can run wormhole
with the --ignore-unsendable-files flag.

blap: No such file or directory
```

And here's what happens when we use the new flag:

```
$ wormhole send breakage --ignore-unsendable-files
Building zipfile..
blap: No such file or directory (ignoring error)
Sending directory (22 Bytes compressed) named 'breakage'
On the other computer, please run: wormhole receive
Wormhole code is: 7-maritime-trojan
```

## To do

- [x] Add test to ensure `UnsendableFileError` is raised when `--ignore-unsendable-files` is not passed.
- [x] Add test to ensure `UnsendableFileError` is *not* raised when `--ignore-unsendable-files` is passed.
