### PR TITLE
Fixes for Versioneer in the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .appveyor.yml
 .coveragerc
 docs
-.git
 .gitattributes
 .gitignore
 misc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,1 @@
-.appveyor.yml
-.coveragerc
-docs
-.gitattributes
-.gitignore
-misc
-snapcraft.yaml
-tox.ini
-.travis.yml
+dist


### PR DESCRIPTION
Versioneer wants git cli installed so it can ask about git revision info.  So, install it.

Versioneer also cares about the name of the source directory.  So, change it.

This gets us a version number like "0.9.2+257.g48b1f02" which is at least better than "0+unknown".  When the next release is tagged, I think it will get a clean version like "0.9.3" (whatever the tag is) which is probably just what we want.

Fixes #168 