### PR TITLE
if the first connection fails, abandon the wormhole

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name="magic-wormhole",
       install_requires=[
           "spake2==0.7", "pynacl",
           "six",
-          "twisted[tls]",
+          "twisted[tls] >= 17.5.0", # 17.5.0 adds failAfterFailures=
           "autobahn[twisted] >= 0.14.1",
           "automat",
           "hkdf",

--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -10,7 +10,8 @@ from . import public_relay
 from .. import __version__
 from ..timing import DebugTiming
 from ..errors import (WrongPasswordError, WelcomeError, KeyFormatError,
-                      TransferError, NoTorError, UnsendableFileError)
+                      TransferError, NoTorError, UnsendableFileError,
+                      ServerConnectionError)
 from twisted.internet.defer import inlineCallbacks, maybeDeferred
 from twisted.python.failure import Failure
 from twisted.internet.task import react
@@ -117,6 +118,11 @@ def _dispatch_command(reactor, cfg, command):
         raise SystemExit(1)
     except TransferError as e:
         print(u"TransferError: %s" % six.text_type(e), file=cfg.stderr)
+        raise SystemExit(1)
+    except ServerConnectionError as e:
+        msg = fill("ERROR: " + dedent(e.__doc__))
+        msg += "\n" + six.text_type(e)
+        print(msg, file=cfg.stderr)
         raise SystemExit(1)
     except Exception as e:
         # this prints a proper traceback, whereas

--- a/src/wormhole/errors.py
+++ b/src/wormhole/errors.py
@@ -16,6 +16,13 @@ class UnsendableFileError(Exception):
 class ServerError(WormholeError):
     """The relay server complained about something we did."""
 
+class ServerConnectionError(WormholeError):
+    """We had a problem connecting to the relay server:"""
+    def __init__(self, reason):
+        self.reason = reason
+    def __str__(self):
+        return str(self.reason)
+
 class Timeout(WormholeError):
     pass
 

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -10,11 +10,12 @@ from twisted.python import procutils, log
 from twisted.internet import endpoints, reactor
 from twisted.internet.utils import getProcessOutputAndValue
 from twisted.internet.defer import gatherResults, inlineCallbacks, returnValue
+from twisted.internet.error import ConnectionRefusedError
 from .. import __version__
 from .common import ServerBase, config
 from ..cli import cmd_send, cmd_receive, welcome, cli
 from ..errors import (TransferError, WrongPasswordError, WelcomeError,
-                      UnsendableFileError)
+                      UnsendableFileError, ServerConnectionError)
 from .._interfaces import ITorManager
 from wormhole.server.cmd_server import MyPlugin
 from wormhole.server.cli import server
@@ -874,6 +875,61 @@ class NotWelcome(ServerBase, unittest.TestCase):
         f = yield self.assertFailure(receive_d, WelcomeError)
         self.assertEqual(str(f), "please upgrade XYZ")
 
+class NoServer(ServerBase, unittest.TestCase):
+    @inlineCallbacks
+    def setUp(self):
+        self._setup_relay(None)
+        yield self._relay_server.disownServiceParent()
+
+    @inlineCallbacks
+    def test_sender(self):
+        cfg = config("send")
+        cfg.hide_progress = True
+        cfg.listen = False
+        cfg.relay_url = self.relayurl
+        cfg.transit_helper = ""
+        cfg.stdout = io.StringIO()
+        cfg.stderr = io.StringIO()
+
+        cfg.text = "hi"
+        cfg.code = "1-abc"
+
+        send_d = cmd_send.send(cfg)
+        e = yield self.assertFailure(send_d, ServerConnectionError)
+        self.assertIsInstance(e.reason, ConnectionRefusedError)
+
+    @inlineCallbacks
+    def test_sender_allocation(self):
+        cfg = config("send")
+        cfg.hide_progress = True
+        cfg.listen = False
+        cfg.relay_url = self.relayurl
+        cfg.transit_helper = ""
+        cfg.stdout = io.StringIO()
+        cfg.stderr = io.StringIO()
+
+        cfg.text = "hi"
+
+        send_d = cmd_send.send(cfg)
+        e = yield self.assertFailure(send_d, ServerConnectionError)
+        self.assertIsInstance(e.reason, ConnectionRefusedError)
+
+    @inlineCallbacks
+    def test_receiver(self):
+        cfg = config("receive")
+        cfg.hide_progress = True
+        cfg.listen = False
+        cfg.relay_url = self.relayurl
+        cfg.transit_helper = ""
+        cfg.stdout = io.StringIO()
+        cfg.stderr = io.StringIO()
+
+        cfg.code = "1-abc"
+
+        receive_d = cmd_receive.receive(cfg)
+        e = yield self.assertFailure(receive_d, ServerConnectionError)
+        self.assertIsInstance(e.reason, ConnectionRefusedError)
+
 class Cleanup(ServerBase, unittest.TestCase):
 
     def make_config(self):
@@ -1081,6 +1137,18 @@ class Dispatch(unittest.TestCase):
         yield self.assertFailure(cli._dispatch_command(reactor, cfg, fake),
                                  SystemExit)
         expected = "TransferError: abcd\n"
+        self.assertEqual(cfg.stderr.getvalue(), expected)
+
+    @inlineCallbacks
+    def test_server_connection_error(self):
+        cfg = config("send")
+        cfg.stderr = io.StringIO()
+        def fake():
+            raise ServerConnectionError(ValueError("abcd"))
+        yield self.assertFailure(cli._dispatch_command(reactor, cfg, fake),
+                                 SystemExit)
+        expected = fill("ERROR: " + dedent(ServerConnectionError.__doc__))+"\n"
+        expected += "abcd\n"
         self.assertEqual(cfg.stderr.getvalue(), expected)
 
     @inlineCallbacks


### PR DESCRIPTION
This provides a clear error in case the user doesn't have an internet
connection at all, or something is so broken with their DNS or routing that
they can't reach the server. I think this is better than waiting and
retrying (silently) forever.

If the first connection succeeds, but is then lost, subsequent retries occur
without fanfare.

closes #68