### PR TITLE
use click.Path to make args.what unicode

### DIFF
--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -183,7 +183,7 @@ TorArgs = _compose(
     "--ignore-unsendable-files", default=False, is_flag=True,
     help="Don't raise an error if a file can't be read."
 )
-@click.argument("what", required=False)
+@click.argument("what", required=False, type=click.Path(path_type=type(u"")))
 @click.pass_obj
 def send(cfg, **kwargs):
     """Send a text message, file, or directory"""

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -232,6 +232,16 @@ class Sender:
             fd_to_send = None
             return offer, fd_to_send
 
+        # click.Path (with resolve_path=False, the default) does not do path
+        # resolution, so we must join it to cwd ourselves. We could use
+        # resolve_path=True, but then it would also do os.path.realpath(),
+        # which would replace the basename with the target of a symlink (if
+        # any), which is not what I think users would want: if you symlink
+        # X->Y and send X, you expect the recipient to save it in X, not Y.
+        #
+        # TODO: an open question is whether args.cwd (i.e. os.getcwd()) will
+        # be unicode or bytes. We need it to be something that can be
+        # os.path.joined with the unicode args.what .
         what = os.path.join(args.cwd, args.what)
         what = what.rstrip(os.sep)
         if not os.path.exists(what):

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -350,7 +350,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
         elif mode in ("file", "empty-file"):
             if mode == "empty-file":
                 message = ""
-            send_filename = "testfile"
+            send_filename = "testfil\u00EB" # e-with-diaeresis
             with open(os.path.join(send_dir, send_filename), "w") as f:
                 f.write(message)
             send_cfg.what = send_filename


### PR DESCRIPTION
refs #157 (unicode paths cause 'wormhole send' to crash), might fix it