### PR TITLE
tests/ServerBase: control advertise_version=

### DIFF
--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -12,7 +12,7 @@ class ServerBase:
     def setUp(self):
         self._setup_relay(None)
 
-    def _setup_relay(self, error):
+    def _setup_relay(self, error, advertise_version=None):
         self.sp = service.MultiService()
         self.sp.startService()
         self.relayport = allocate_tcp_port()
@@ -21,7 +21,7 @@ class ServerBase:
         # endpoints.serverFromString
         s = RelayServer("tcp:%d:interface=127.0.0.1" % self.relayport,
                         "tcp:%s:interface=127.0.0.1" % self.transitport,
-                        advertise_version="advertised.version",
+                        advertise_version=advertise_version,
                         signal_error=error)
         s.setServiceParent(self.sp)
         self._relay_server = s

--- a/src/wormhole/test/test_server.py
+++ b/src/wormhole/test/test_server.py
@@ -605,7 +605,7 @@ class WSClientSync(unittest.TestCase):
 class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
     def setUp(self):
         self._clients = []
-        return ServerBase.setUp(self)
+        self._setup_relay(None, advertise_version="advertised.version")
 
     def tearDown(self):
         for c in self._clients:

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -105,6 +105,10 @@ class Delegated(ServerBase, unittest.TestCase):
 class Wormholes(ServerBase, unittest.TestCase):
     # integration test, with a real server
 
+    def setUp(self):
+        # test_welcome wants to see [current_cli_version]
+        self._setup_relay(None, advertise_version="advertised.version")
+
     def doBoth(self, d1, d2):
         return gatherResults([d1, d2], True)
 


### PR DESCRIPTION
we'll disable this for most tests, but a few want to see it in the welcome
message