### PR TITLE
handle WebSocket protocol errors correctly

### DIFF
--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -120,8 +120,9 @@ def _dispatch_command(reactor, cfg, command):
         print(u"TransferError: %s" % six.text_type(e), file=cfg.stderr)
         raise SystemExit(1)
     except ServerConnectionError as e:
-        msg = fill("ERROR: " + dedent(e.__doc__))
-        msg += "\n" + six.text_type(e)
+        msg = fill("ERROR: " + dedent(e.__doc__)) + "\n"
+        msg += "(relay URL was %s)\n" % e.url
+        msg += six.text_type(e)
         print(msg, file=cfg.stderr)
         raise SystemExit(1)
     except Exception as e:

--- a/src/wormhole/errors.py
+++ b/src/wormhole/errors.py
@@ -18,7 +18,8 @@ class ServerError(WormholeError):
 
 class ServerConnectionError(WormholeError):
     """We had a problem connecting to the relay server:"""
-    def __init__(self, reason):
+    def __init__(self, url, reason):
+        self.url = url
         self.reason = reason
     def __str__(self):
         return str(self.reason)

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -1144,10 +1144,11 @@ class Dispatch(unittest.TestCase):
         cfg = config("send")
         cfg.stderr = io.StringIO()
         def fake():
-            raise ServerConnectionError(ValueError("abcd"))
+            raise ServerConnectionError("URL", ValueError("abcd"))
         yield self.assertFailure(cli._dispatch_command(reactor, cfg, fake),
                                  SystemExit)
         expected = fill("ERROR: " + dedent(ServerConnectionError.__doc__))+"\n"
+        expected += "(relay URL was URL)\n"
         expected += "abcd\n"
         self.assertEqual(cfg.stderr.getvalue(), expected)
 


### PR DESCRIPTION
The previous behavior was to throw an Automat exception, when a state machine
was given a LOST event from the initial non-connected state, and it didn't
have a handler for it. This version throws ServerConnectionError instead.

Still needs a test

refs #180