### PR TITLE
Make default option of prompt uppercase

### DIFF
--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -339,7 +339,7 @@ class Receiver:
     def _ask_permission(self):
         with self.args.timing.add("permission", waiting="user") as t:
             while True and not self.args.accept_file:
-                ok = six.moves.input("ok? (y/n): ")
+                ok = six.moves.input("ok? (y/N): ")
                 if ok.lower().startswith("y"):
                     if os.path.exists(self.abs_destname):
                         self._remove_existing(self.abs_destname)


### PR DESCRIPTION
Makes it clear what happens when user just presses `Enter`

See: https://stackoverflow.com/questions/7803728/standard-format-for-yes-no-questions-in-the-terminal