### PR TITLE
Use the latest git tag as the snap version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: wormhole
-version: master
+version: git
 summary: get things from one computer to another, safely
 description: |
   This package provides a library and a command-line tool named wormhole,


### PR DESCRIPTION
With this change it's easier to automate the continuous delivery of the snap, because when a verified tag is pushed to the repo the snap will get that version. There will be no need to manually change the version in the snapcraft.yaml.