### PR TITLE
Change the send command output to help copy and pasting to others

### DIFF
--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -100,9 +100,6 @@ class Sender:
             args.code = u"0-"
             other_cmd += " -0"
 
-        print(u"On the other computer, please run: %s" % other_cmd,
-              file=args.stderr)
-
         if args.code:
             w.set_code(args.code)
         else:
@@ -111,9 +108,12 @@ class Sender:
         code = yield w.get_code()
         if not args.zeromode:
             print(u"Wormhole code is: %s" % code, file=args.stderr)
+            print(u"On the other computer, please run:", file=args.stderr)
+            print(u"", file=args.stderr)
+            print(u"%s %s" % (other_cmd, code), file=args.stderr)
+            print(u"", file=args.stderr)
             # flush stderr so the code is displayed immediately
             args.stderr.flush()
-        print(u"", file=args.stderr)
 
         # We don't print a "waiting" message for get_unverified_key() here,
         # even though we do that in cmd_receive.py, because it's not at all

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -589,9 +589,9 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
         # check sender
         if mode == "text" or mode == "slow-text":
             expected = ("Sending text message ({bytes:d} Bytes){NL}"
-                        "On the other computer, please run: "
-                        "wormhole receive{NL}"
-                        "Wormhole code is: {code}{NL}{NL}"
+                        "Wormhole code is: {code}{NL}"
+                        "On the other computer, please run:{NL}{NL}"
+                        "wormhole receive {code}{NL}{NL}"
                         "{KE}"
                         "text message sent{NL}").format(bytes=len(message),
                                                         code=send_cfg.code,
@@ -603,9 +603,9 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
                               .format(size=naturalsize(len(message)),
                                       name=send_filename,
                                       NL=NL), send_stderr)
-            self.failUnlessIn(u"On the other computer, please run: "
-                              "wormhole receive{NL}"
-                              "Wormhole code is: {code}{NL}{NL}"
+            self.failUnlessIn(u"Wormhole code is: {code}{NL}"
+                              "On the other computer, please run:{NL}{NL}"
+                              "wormhole receive {code}{NL}{NL}"
                               .format(code=send_cfg.code, NL=NL),
                               send_stderr)
             self.failUnlessIn(u"File sent.. waiting for confirmation{NL}"
@@ -614,9 +614,9 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
         elif mode == "directory":
             self.failUnlessIn(u"Sending directory", send_stderr)
             self.failUnlessIn(u"named 'testdir'", send_stderr)
-            self.failUnlessIn(u"On the other computer, please run: "
-                              "wormhole receive{NL}"
-                              "Wormhole code is: {code}{NL}{NL}"
+            self.failUnlessIn(u"Wormhole code is: {code}{NL}"
+                              "On the other computer, please run:{NL}{NL}"
+                              "wormhole receive {code}{NL}{NL}"
                               .format(code=send_cfg.code, NL=NL), send_stderr)
             self.failUnlessIn(u"File sent.. waiting for confirmation{NL}"
                               "Confirmation received. Transfer complete.{NL}"
@@ -788,9 +788,9 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
                               .format(size=naturalsize(size),
                                       name=send_filename,
                                       NL=NL), send_stderr)
-            self.failUnlessIn("On the other computer, please run: "
-                              "wormhole receive{NL}"
-                              "Wormhole code is: {code}{NL}{NL}"
+            self.failUnlessIn("Wormhole code is: {code}{NL}"
+                              "On the other computer, please run:{NL}{NL}"
+                              "wormhole receive {code}{NL}"
                               .format(code=send_cfg.code, NL=NL),
                               send_stderr)
             self.failIfIn("File sent.. waiting for confirmation{NL}"
@@ -799,9 +799,9 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
         elif mode == "directory":
             self.failUnlessIn("Sending directory", send_stderr)
             self.failUnlessIn("named 'testdir'", send_stderr)
-            self.failUnlessIn("On the other computer, please run: "
-                              "wormhole receive{NL}"
-                              "Wormhole code is: {code}{NL}{NL}"
+            self.failUnlessIn("Wormhole code is: {code}{NL}"
+                              "On the other computer, please run:{NL}{NL}"
+                              "wormhole receive {code}{NL}"
                               .format(code=send_cfg.code, NL=NL), send_stderr)
             self.failIfIn("File sent.. waiting for confirmation{NL}"
                           "Confirmation received. Transfer complete.{NL}"
@@ -893,8 +893,6 @@ class ZeroMode(ServerBase, unittest.TestCase):
 
         # check sender
         expected = ("Sending text message ({bytes:d} Bytes){NL}"
-                    "On the other computer, please run: "
-                    "wormhole receive -0{NL}{NL}"
                     "text message sent{NL}").format(bytes=len(message),
                                                     code=send_cfg.code,
                                                     NL=NL)


### PR DESCRIPTION
A tiny update to show the command to execute along with the code required on
the same line, rather than split across two lines. This small change helps
when sending the information to others using copy and paste.

Fixes #266

-=david=-