### PR TITLE
Do not refer to transit server in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,8 @@ ENV WORMHOLE_USER_NAME="wormhole"
 RUN adduser --uid 1000 --disabled-password --gecos "" "${WORMHOLE_USER_NAME}"
 
 # Facilitate network connections to the application.  The rendezvous server
-# listens on 4000 by default.  The transit relay server on 4001.
+# listens on 4000 by default.
 EXPOSE 4000
-EXPOSE 4001
 
 # Put the source somewhere pip will be able to see it.
 ADD . /magic-wormhole
@@ -87,4 +86,4 @@ ENTRYPOINT ["/app/env/bin/wormhole-server", "start", "--no-daemon"]
 
 # By default, start up a pretty reasonable server.  This can easily be
 # overridden by another command which will get added to the entrypoint.
-CMD ["--rendezvous", "tcp:4000", "--transit", "tcp:4001"]
+CMD ["--rendezvous", "tcp:4000"]


### PR DESCRIPTION
https://github.com/warner/magic-wormhole/pull/263 removed the transit server,
breaking the Dockerfile.

This fixes the Dockerfile to run just the rendezvous server.