### PR TITLE
Add snapcraft support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,32 @@
+name: wormhole
+version: git
+summary: get things from one computer to another, safely
+description: |
+  This package provides a library and a command-line tool named wormhole, which
+  makes it possible to get arbitrary-sized files and directories (or short
+  pieces of text) from one computer to another. The two endpoints are identified
+  by using identical "wormhole codes": in general, the sending machine generates
+  and displays the code, which must then be typed into the receiving machine.
+grade: stable
+confinement: strict
+
+apps:
+  wormhole:
+    command: bin/wormhole
+    plugs:
+      - network
+      - network-bind
+      - home
+      - removable-media
+
+parts:
+  wormhole:
+    plugin: python
+    python-version: python2
+    source: .
+    build-packages:
+      - build-essential
+      - python-dev
+      - libffi-dev
+      - libssl-dev
+      - libsodium-dev


### PR DESCRIPTION
This pull request adds support to build magic-wormhole as a snap.

magic-wormhole is already [available](https://snapcraft.io/wormhole/) in the snap store via the yaml in the [snapcrafter](https://github.com/snapcrafters/magic-wormhole) repo.

This PR is to upstream the snapcraft.yaml which creates the snap which is in the store. If the PR is accepted, we can transfer ownership of the magic-wormhole snap to you, the upstream developer. Once done you could use the free build.snapcraft.io service to automatically build new releases of magic-wormhole and push directly to the store. 

If accepted, I'm happy to walk you through the next steps. 