### PR TITLE
setup.py: remove the dependency on ipaddress

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(name="magic-wormhole",
           "tqdm >= 4.13.0", # 4.13.0 fixes crash on NetBSD
           "click",
           "humanize",
-          "ipaddress",
           "txtorcon >= 0.19.3",
       ],
       extras_require={


### PR DESCRIPTION
Do we still need this? Nothing in wormhole uses it.

refs #274