### PR TITLE
let tests override KEY_TIMER/VERIFY_TIMER to tolerate slow test hosts

### DIFF
--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -14,8 +14,8 @@ from .welcome import handle_welcome
 
 APPID = u"lothar.com/wormhole/text-or-file-xfer"
 
-KEY_TIMER = 1.0
-VERIFY_TIMER = 1.0
+KEY_TIMER = float(os.environ.get("_MAGIC_WORMHOLE_TEST_KEY_TIMER", 1.0))
+VERIFY_TIMER = float(os.environ.get("_MAGIC_WORMHOLE_TEST_VERIFY_TIMER", 1.0))
 
 class RespondError(Exception):
     def __init__(self, response):

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -13,7 +13,7 @@ from ..util import dict_to_bytes, bytes_to_dict, bytes_to_hexstr
 from .welcome import handle_welcome
 
 APPID = u"lothar.com/wormhole/text-or-file-xfer"
-VERIFY_TIMER = 1
+VERIFY_TIMER = float(os.environ.get("_MAGIC_WORMHOLE_TEST_VERIFY_TIMER", 1.0))
 
 def send(args, reactor=reactor):
     """I implement 'wormhole send'. I return a Deferred that fires with None


### PR DESCRIPTION
I've seen intermittent failures in
test_cli.PregeneratedCode.test_text_subprocess where the host was slow (or
overloaded) enough that the "Waiting for sender.." pacifier message was
displayed, which flunks the test because we're looking for a specific output
string. We patch this 1-second timer in the non-subprocess tests, but you
can't patch across a process boundary.

This patch adds an undocumented environment variable that lets you override
the timer values. The test then sets it to something large.

For future consideration: another approach would be to change the test to
tolerate the extra message. This would be trickier to validate, though.