### PR TITLE
use pyinstaller to build wormhole fat/standalone binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,12 +24,6 @@ var/
 MANIFEST
 .eggs
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/pyi/build-exe
+++ b/pyi/build-exe
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# use pyinstaller to build a single-file "fat binary" called wormhole.exe.
+#
+# the .exe here does NOT mean a windows executable, but an executable in general.
+#
+# "fat binary" means it includes the python interpreter, the python source code
+# and libs, compiled code parts and externally needed (C/compiled) libraries.
+# it does NOT include the (g)libc though as this needs to be provided by the
+# target platform and needs to match the kernel there. thus, it is a good idea
+# to run the build on an old, but still security-supported linux (or other posix
+# OS) to keep the minimum (g)libc requirement low.
+
+pyinstaller --clean --distpath=dist wormhole.exe.spec
+
+# result will be in dist/wormhole.exe
+

--- a/pyi/wormhole.exe.spec
+++ b/pyi/wormhole.exe.spec
@@ -1,0 +1,43 @@
+# -*- mode: python -*-
+# this pyinstaller spec file is used to build wormhole binaries on posix platforms
+
+import os, sys
+
+# your cwd should be in the same dir as this file, so .. is the project directory:
+basepath = os.path.realpath('..')
+
+a = Analysis([os.path.join(basepath, 'src/wormhole/__main__.py'), ],
+             pathex=[basepath, ],
+             binaries=[],
+             datas=[],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=None)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=None)
+
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='wormhole.exe',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True)
+
+if False:
+    # Enable this block to build a directory-based binary instead of
+    # a packed single file.
+    coll = COLLECT(exe,
+                   a.binaries,
+                   a.zipfiles,
+                   a.datas,
+                   strip=False,
+                   upx=True,
+                   name='wormhole-dir')

--- a/src/wormhole/__main__.py
+++ b/src/wormhole/__main__.py
@@ -2,7 +2,7 @@ if __name__ != "__main__":
     raise ImportError('this module should not be imported')
 
 
-from .cli import cli
+from wormhole.cli import cli
 
 
 cli.wormhole()


### PR DESCRIPTION
tested with/on:
- ubuntu linux 18.04 amd64
- pyinstaller 3.3.1 (pip install pyinstaller)
- python 3.6.5

There is a good chance it also works on FreeBSD, maybe also on macOS.

The change in `__main__.py` was required because otherwise it complains about `__main__` not being a package when trying the dot-relative import.