### PR TITLE
Closes #330 Changed default choice from No to Yes for wormhole receive

### DIFF
--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -369,8 +369,8 @@ class Receiver:
     def _ask_permission(self):
         with self.args.timing.add("permission", waiting="user") as t:
             while True and not self.args.accept_file:
-                ok = six.moves.input("ok? (y/N): ")
-                if ok.lower().startswith("y"):
+                ok = six.moves.input("ok? (Y/n): ")
+                if not ok.lower().startswith("n"):
                     if os.path.exists(self.abs_destname):
                         self._remove_existing(self.abs_destname)
                     break


### PR DESCRIPTION
I've simply changed the default for receive to Yes. Unless specifically typing `n` or `N` receive defaults to accept receive upon carriage return.