### PR TITLE
transit key is derived from the wrong APPID, bummer

### DIFF
--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -245,7 +245,12 @@ class Receiver:
             reactor=self._reactor,
             timing=self.args.timing)
         self._transit_receiver = tr
-        transit_key = w.derive_key(APPID + u"/transit-key",
+        # When I made it possible to override APPID with a CLI argument
+        # (issue #113), I forgot to also change this w.derive_key() (issue
+        # #339). We're stuck with it now. Use a local constant to make this
+        # clear.
+        BUG339_APPID = u"lothar.com/wormhole/text-or-file-xfer"
+        transit_key = w.derive_key(BUG339_APPID + u"/transit-key",
                                    tr.TRANSIT_KEY_LENGTH)
         tr.set_transit_key(transit_key)
 

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -181,8 +181,14 @@ class Sender:
             }
             self._send_data({u"transit": sender_transit}, w)
 
+            # When I made it possible to override APPID with a CLI argument
+            # (issue #113), I forgot to also change this w.derive_key()
+            # (issue #339). We're stuck with it now. Use a local constant to
+            # make this clear.
+            BUG339_APPID = u"lothar.com/wormhole/text-or-file-xfer"
+
             # TODO: move this down below w.get_message()
-            transit_key = w.derive_key(APPID + "/transit-key",
+            transit_key = w.derive_key(BUG339_APPID + "/transit-key",
                                        ts.TRANSIT_KEY_LENGTH)
             ts.set_transit_key(transit_key)
 


### PR DESCRIPTION
When I made it possible to override APPID with a CLI argument (issue #113), I
forgot to also change this w.derive_key() (issue #339). We don't really need
to include APPID in that purpose string at all (the ideal code would be just
`w.derive_key("transit-key", length)`), but we're stuck with it now. Both
sides must use the same derivation process, and it would be pretty
expensive/complicated to negotiate the process ahead of time (and this code
is scheduled to be obsoleted by Dilation anyways).

I added a note to the two sites that use it, and put a local copy of the
APPID there. We should treat that copy as an arbitrary magic string that must
be included for compatibility with existing deployments (potential
file-transfer peers), which is coincidentally similar to the default `APPID`.

closes #339