### PR TITLE
Add installation instructions for openSUSE

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -70,6 +70,12 @@ $ sudo apt install magic-wormhole
 $ sudo dnf install magic-wormhole
 ```
 
+### Linux (openSUSE)
+
+```
+$ sudo zypper install python-magic-wormhole
+```
+
 ### Linux (Snap package)
 
 Many linux distributions (including Ubuntu) can install ["Snap"


### PR DESCRIPTION
magic-wormhole has been included in openSUSE since Leap 15.1, and is
also available in Tumbleweed:

https://software.opensuse.org/package/python-magic-wormhole

So document this explicitly.