### PR TITLE
Remove deprecated keyword "sudo" from travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 # defaults: the py3.7 environment overrides these
 dist: trusty
-sudo: false
 
 cache: pip
 before_cache:


### PR DESCRIPTION
cf.
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

modified:   .travis.yml