### PR TITLE
fix test that fails under Twisted-19.10

### DIFF
--- a/src/wormhole/_dilation/manager.py
+++ b/src/wormhole/_dilation/manager.py
@@ -92,7 +92,7 @@ def make_side():
 #   can send HINTS, but it must not be given any HINTS that arrive before
 #   RECONNECTING (since they're probably stale)
 
-# * after VERSIONS(KCM) received, we might learn that they other side cannot
+# * after VERSIONS(KCM) received, we might learn that the other side cannot
 #    dilate. w.dilate errbacks at this point
 
 # * maybe signal warning if we stay in a "want" state for too long

--- a/src/wormhole/test/dilate/test_manager.py
+++ b/src/wormhole/test/dilate/test_manager.py
@@ -237,15 +237,17 @@ class TestManager(unittest.TestCase):
             ])
         clear_mock_calls(h.inbound)
 
+        eps = m.get_endpoints()
+        self.assertTrue(hasattr(eps, "control"))
+        self.assertTrue(hasattr(eps, "connect"))
+        self.assertEqual(eps.listen, h.listen_ep)
+
         m.got_wormhole_versions({"can-dilate": ["1"]})
         self.assertEqual(h.send.mock_calls, [
             mock.call.send("dilate-0",
                            dict_to_bytes({"type": "please", "side": LEADER}))
             ])
         clear_mock_calls(h.send)
-
-        listen_d = m.get_endpoints().listen.listen(None)
-        self.assertNoResult(listen_d)
 
         # ignore early hints
         m.rx_HINTS({})
@@ -266,8 +268,6 @@ class TestManager(unittest.TestCase):
             ])
         self.assertEqual(c.mock_calls, [mock.call.start()])
         clear_mock_calls(connector, c)
-
-        self.assertNoResult(listen_d)
 
         # now any inbound hints should get passed to our Connector
         with mock.patch("wormhole._dilation.manager.parse_hint",


### PR DESCRIPTION

This test was incorrectly exercising a member of the endpoint record returned
by `Manager.get_endpoints()`. In the test environment, the `.listen` Endpoint
is actually a Mock, so calling e.g. `listen()` on `endpoints.listen` returns
another Mock instead of a Deferred. Twisted's `assertNoResult` used to
tolerate this silently, but as of Twisted-19.10 it throws an error, causing
the test to fail.

The fix is to assert that the record has attributes with the right names, but
not assume they behave like normal Endpoints, and not call `.listen()` on
them.

closes #366
