### PR TITLE
Reactor import improvements

### DIFF
--- a/src/wormhole/transit.py
+++ b/src/wormhole/transit.py
@@ -10,8 +10,9 @@ from collections import deque
 
 import six
 from nacl.secret import SecretBox
+import twisted.internet
 from twisted.internet import (address, defer, endpoints, error, interfaces,
-                              protocol, reactor, task)
+                              protocol, task)
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.protocols import policies
 from twisted.python import log
@@ -559,7 +560,7 @@ class Common:
                  transit_relay,
                  no_listen=False,
                  tor=None,
-                 reactor=reactor,
+                 reactor=None,
                  timing=None):
         self._side = bytes_to_hexstr(os.urandom(8))  # unicode
         if transit_relay:
@@ -579,6 +580,8 @@ class Common:
         self._waiting_for_transit_key = []
         self._listener = None
         self._winner = None
+        if reactor is None:
+            reactor = twisted.internet.reactor
         self._reactor = reactor
         self._timing = timing or DebugTiming()
         self._timing.add("transit")
@@ -596,7 +599,7 @@ class Common:
         direct_hints = [
             DirectTCPV1Hint(six.u(addr), portnum, 0.0) for addr in addresses
         ]
-        ep = endpoints.serverFromString(reactor, "tcp:%d" % portnum)
+        ep = endpoints.serverFromString(twisted.internet.reactor, "tcp:%d" % portnum)
         return direct_hints, ep
 
     def get_connection_abilities(self):


### PR DESCRIPTION
This PR removes a module-level import of twisted.internet.reactor. This import has side effects, which can cause problems when using a non-default reactor (qt5reactor, for example).

For me this led to a bug where transit would connect via the relay but never directly to the peer. Changing the order of imports in the calling module fixed the problem, but this PR should stop it happening again.
