### PR TITLE
Replace deprecated attrs `cmp=False` parameter with `eq=False`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name="magic-wormhole",
       install_requires=[
           "spake2==0.8", "pynacl",
           "six",
-          "attrs >= 16.3.0", # 16.3.0 adds __attrs_post_init__
+          "attrs >= 19.2.0", # 19.2.0 replaces cmp parameter with eq/order
           "twisted[tls] >= 17.5.0", # 17.5.0 adds failAfterFailures=
           "autobahn[twisted] >= 0.14.1",
           "automat",

--- a/src/wormhole/_dilation/connection.py
+++ b/src/wormhole/_dilation/connection.py
@@ -459,7 +459,7 @@ class _Record(object):
         self._framer.send_frame(frame)
 
 
-@attrs(cmp=False)
+@attrs(eq=False)
 class DilatedConnectionProtocol(Protocol, object):
     """I manage an L2 connection.
 

--- a/src/wormhole/_dilation/connector.py
+++ b/src/wormhole/_dilation/connector.py
@@ -43,7 +43,7 @@ NOISEPROTO = b"Noise_NNpsk0_25519_ChaChaPoly_BLAKE2s"
 def build_noise():
     return NoiseConnection.from_name(NOISEPROTO)
 
-@attrs(cmp=False)
+@attrs(eq=False)
 @implementer(IDilationConnector)
 class Connector(object):
     """I manage a single generation of connection.

--- a/src/wormhole/_dilation/manager.py
+++ b/src/wormhole/_dilation/manager.py
@@ -104,7 +104,7 @@ def make_side():
 # * if follower calls w.dilate() but not leader, follower waits forever
 #   in "want", leader waits forever in "wanted"
 
-@attrs(cmp=False)
+@attrs(eq=False)
 @implementer(IDilationManager)
 class Manager(object):
     _S = attrib(validator=provides(ISend), repr=False)

--- a/src/wormhole/_dilation/outbound.py
+++ b/src/wormhole/_dilation/outbound.py
@@ -340,7 +340,7 @@ class Outbound(object):
 # modelled after twisted.internet._producer_helper._PullToPush , but with a
 # configurable Cooperator, a pause-immediately argument to startStreaming()
 @implementer(IPushProducer)
-@attrs(cmp=False)
+@attrs(eq=False)
 class PullToPush(object):
     _producer = attrib(validator=provides(IPullProducer))
     _unregister = attrib(validator=lambda _a, _b, v: callable(v))

--- a/src/wormhole/_dilation/subchannel.py
+++ b/src/wormhole/_dilation/subchannel.py
@@ -73,7 +73,7 @@ class _SubchannelAddress(object):
     _scid = attrib(validator=instance_of(six.integer_types))
 
 
-@attrs(cmp=False)
+@attrs(eq=False)
 @implementer(ITransport)
 @implementer(IProducer)
 @implementer(IConsumer)


### PR DESCRIPTION
See https://attrs.readthedocs.io/en/stable/api.html#core

